### PR TITLE
(minor) Fix logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![Logo of Consul]
-(https://raw.githubusercontent.com/consul/consul/master/public/consul_logo.png)
+![Logo of Consul](https://raw.githubusercontent.com/consul/consul/master/public/consul_logo.png)
 
 # Consul
 


### PR DESCRIPTION
The logo in the README on Github had extra whitespace that was preventing the graphic from showing.